### PR TITLE
Add CMake presets file

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,25 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "runtimecore",
+      "cacheVariables": {
+        "MZ_COMPAT": "ON",
+        "MZ_ZLIB": "ON",
+        "MZ_BZIP2": "OFF",
+        "MZ_LZMA": "OFF",
+        "MZ_ZSTD": "OFF",
+        "MZ_LIBCOMP": "OFF",
+        "MZ_FETCH_LIBS": "OFF",
+        "MZ_PKCRYPT": "OFF",
+        "MZ_WZAES": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "runtimecore",
+      "configurePreset": "runtimecore"
+    }
+  ]
+}


### PR DESCRIPTION
Include a CMakePresets.json file. This defines the `runtimecore` configure preset, which defines the CMake variables used to configure minizip-ng for building.

This file is needed so that minizip-ng can be configured consistently in future upgrades.